### PR TITLE
chore: add notification onboarding start type

### DIFF
--- a/typeset/notification.go
+++ b/typeset/notification.go
@@ -40,4 +40,6 @@ const (
 	NOTIFICATION_TIP
 	// NOTIFICATION_PAY_REQUEST: Notification when user create paylink/payme
 	NOTIFICATION_PAY_REQUEST
+	// NOTIFICATION_ONBOARDING_START: Notification when user use /start command on the first time
+	NOTIFICATION_ONBOARDING_START
 )


### PR DESCRIPTION
## What does this PR do

- [x] add new notification type: `NOTIFICATION_ONBOARDING_START`