### PR TITLE
fix: audit telegram log - user id type

### DIFF
--- a/queue/audit-log/typeset/telegram.go
+++ b/queue/audit-log/typeset/telegram.go
@@ -18,7 +18,7 @@ type AuditLogTelegram struct {
 
 		// Mentions contains list of users mentioned in the telegram message/command
 		Mentions []struct {
-			UserId   int64  `json:"user_id,omitempty"`
+			UserId   string `json:"user_id,omitempty"`
 			Username string `json:"user_name,omitempty"`
 		} `json:"mentions,omitempty"`
 	} `json:"message,omitempty"`


### PR DESCRIPTION
**What does this PR do?**
- [x] Update type of `mentions.user_id` in audit telegram log